### PR TITLE
Permit interpolation with or without one-space padding.

### DIFF
--- a/client/clang/directive/interpolate.cljs
+++ b/client/clang/directive/interpolate.cljs
@@ -4,10 +4,8 @@
   (:require [clojure.string :as cs])
   (:use [clang.util :only [? ! module]]))
 
-(def start "{{")
-(def end "}}")
-(def re-start #"\{\{")
-(def re-end #"}}")
+(def re-start #"\{\{ ?")
+(def re-end #"? }}")
 
 (def m (module "clang"))
 


### PR DESCRIPTION
In other words, both `{{ foo }}` and `{{foo}}` will be permitted. AngularJS allows both forms, and there does not seem to be an established idiom. Also removed unused `start` and `end` vars from clang.directive.interpolate namespace.
