### PR TITLE
Correct broken regular expression, reference to removed var

### DIFF
--- a/client/clang/directive/clangRepeat.cljs
+++ b/client/clang/directive/clangRepeat.cljs
@@ -1,7 +1,7 @@
 (ns clang.directive.clangRepeat
   (:require-macros [clang.angular :refer [def.directive def.fn ??]])
   (:require clang.directive.interpolate)
-  (:use [clang.util :only [? ! module]]))
+  (:use [clang.util :only [? module]]))
 
 (def m (module "clang"))
 
@@ -61,7 +61,7 @@
                        (swap! lastOrder dissoc value)
                        (swap! nextOrder assoc value last)
                        (when-not (= index (:index last))
-                         (! last :index index)
+                         (assoc! last :index index)
                          (.after @cursor (:element last)))
                        (reset! cursor (:element last))
                        (populate-scope (:scope last) index value))

--- a/client/clang/directive/interpolate.cljs
+++ b/client/clang/directive/interpolate.cljs
@@ -1,8 +1,9 @@
 (ns clang.directive.interpolate
   (:require-macros
     [clang.angular :refer [def.value def.provider fnj ??]])
-  (:require [clojure.string :as cs])
-  (:use [clang.util :only [? ! module]]))
+  (:require
+   [clojure.string :as cs]
+   [clang.util :refer [? module]]))
 
 (def re-start #"\{\{ ?")
 (def re-end #" ?}}")

--- a/client/clang/directive/interpolate.cljs
+++ b/client/clang/directive/interpolate.cljs
@@ -5,8 +5,8 @@
    [clojure.string :as cs]
    [clang.util :refer [? module]]))
 
-(def re-start #"\{\{ ?")
-(def re-end #" ?}}")
+(def re-start #"\{\{ *")
+(def re-end #" *}}")
 
 (def m (module "clang"))
 

--- a/client/clang/directive/interpolate.cljs
+++ b/client/clang/directive/interpolate.cljs
@@ -5,7 +5,7 @@
   (:use [clang.util :only [? ! module]]))
 
 (def re-start #"\{\{ ?")
-(def re-end #"? }}")
+(def re-end #" ?}}")
 
 (def m (module "clang"))
 

--- a/sample/todo.cljs
+++ b/sample/todo.cljs
@@ -12,8 +12,8 @@
 
 (def.controller m TodoCtrl [$scope]
   (assoc! $scope :todos [{:text "learn angular" :done "yes"}
-                        {:text "learn cljs" :done "yes"}
-                        {:text "build an app" :done "no"}])
+                         {:text "learn cljs" :done "yes"}
+                         {:text "build an app" :done "no"}])
 
   (assoc! $scope :nums (range 1 10))
 
@@ -29,23 +29,23 @@
   (defn.scope addTodo []
     (? "addTodo")
     (assoc! $scope :todos (conj (:todos $scope)
-                        {:text (:todoText $scope) :done false}))
+                                {:text (:todoText $scope) :done false}))
     (assoc! $scope :todoText ""))
 
   (defn.scope remaining []
     (->>
-      (:todos $scope)
-      (map :done)
-      (remove #{"yes"})
-      count))
+     (:todos $scope)
+     (map :done)
+     (remove #{"yes"})
+     count))
 
   (defn.scope archive []
     (? "archive")
     (assoc! $scope :todos
             (->>
-              (:todos $scope)
-              (map :done)
-              (remove #{"yes"})))))
+             (:todos $scope)
+             (map :done)
+             (remove #{"yes"})))))
 
 
 
@@ -54,9 +54,9 @@
 
 (def.controller m AtomTodoCtrl [$scope]
   (assoc! $scope :todos (atom [(atom {:text "learn angular" :done true})
-                       (atom {:text "learn cljs" :done true})
-                       (atom {:text "learn about software transactional memory" :done true})
-                       (atom {:text "build an app" :done false})]))
+                               (atom {:text "learn cljs" :done true})
+                               (atom {:text "learn about software transactional memory" :done true})
+                               (atom {:text "build an app" :done false})]))
 
   (defn.scope addTodo []
     (? "addTodo2")


### PR DESCRIPTION
This solves the issue where the code wouldn't even compile because of an invalid regular expression introduced in #13. Also I dropped `!` from the list of refers in `clang.directive.clangRepeat` since it was removed in 7a9ce9d. This was actually causing JavaScript to complain in some instances. Try adding a few dozen todos using the "Basic Todo sample with clojure data" and you'll see the complaints.

```
TypeError: Cannot call method 'call' of undefined
    at Object.clangRepeatWatch [as fn] (file://localhost/Users/choldbrooks/git/clang/resources/public/js/clang_dbg.js:22398:33)
    at Object.Scope.$digest (file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:8037:27)
    at Object.Scope.$apply (file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:8238:24)
    at HTMLFormElement.<anonymous> (file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:13471:11)
    at file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:1979:10
    at Array.forEach (native)
    at forEach (file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:153:11)
    at HTMLFormElement.eventHandler (file://localhost/Users/choldbrooks/git/clang/resources/public/js/angular.js:1978:5) 
```
